### PR TITLE
Remove patch version from Faraday dependency

### DIFF
--- a/fraudrecord.gemspec
+++ b/fraudrecord.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '> 2.0.0'
   
   # Runtime Dependencies
-  gem.add_runtime_dependency 'faraday', '~> 0.9.0'
+  gem.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.0'
   
   # Development Dependencies
   gem.add_development_dependency 'vcr', '~> 2.8.0'


### PR DESCRIPTION
Remove the patch version from the Faraday dependency, but add a minimum Faraday dependency to be equal to the original semver value.

With the patch version in place, FraudRecord cannot be used with latest Stripe gem (which is at `~> 0.14` for dependency requirements).